### PR TITLE
Don't need CS Scripting and minor stuff

### DIFF
--- a/NT Cybernetics/Lua/Scripts/items.lua
+++ b/NT Cybernetics/Lua/Scripts/items.lua
@@ -20,6 +20,7 @@ Hook.Add("item.applyTreatment", "NTCyb.itemused", function(item, usingCharacter,
 end)
 
 local function forceSyncAfflictions(character)
+    if Game.IsSingleplayer then return end
     -- force sync afflictions, as normally they aren't synced for dead characters
     Networking.CreateEntityEvent(character, Character.CharacterStatusEventData.__new(true))
 end


### PR DESCRIPTION
Got rid of needing to register System.Single so mod can run without CS Scripting enabled
RegisterType now uses the specific subtype instead of the entire genetic type
Simpler check for empty array
Dont network in Singleplayer